### PR TITLE
Migrate from golint to golangci-lint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,169 @@
+version: 2
+
+run:
+  # Timeout for analysis
+  timeout: 5m
+
+  # Which dirs to skip: issues from them won't be reported
+  skip-dirs:
+    - vendor
+
+  # Which files to skip: they will be analyzed, but issues from them won't be reported
+  skip-files:
+    - ".*\\.pb\\.go$"
+    - ".*\\.gen\\.go$"
+
+linters:
+  enable:
+    # Default linters (enabled by default in golangci-lint)
+    - errcheck      # Check for unchecked errors
+    - govet         # Reports suspicious constructs
+    - ineffassign   # Detect ineffectual assignments
+    - staticcheck   # Go static analysis
+    - unused        # Check for unused code
+
+    # Additional recommended linters
+    - revive        # Fast, configurable, extensible, flexible, and beautiful linter for Go (drop-in replacement for golint)
+    - misspell      # Finds commonly misspelled English words
+    - bodyclose     # Checks whether HTTP response body is closed successfully
+    - dogsled       # Checks assignments with too many blank identifiers
+    - dupl          # Tool for code clone detection
+    - exhaustive    # Check exhaustiveness of enum switch statements
+    - gochecknoinits # Checks that no init functions are present
+    - goconst       # Finds repeated strings that could be replaced by a constant
+    - gocritic      # Provides diagnostics that check for bugs, performance and style issues
+    - gocyclo       # Computes and checks the cyclomatic complexity of functions
+    - goprintffuncname # Checks that printf-like functions are named with f at the end
+    - gosec         # Inspects source code for security problems
+    - nakedret      # Finds naked returns in functions greater than a specified function length
+    - noctx         # Finds sending http request without context.Context
+    - nolintlint    # Reports ill-formed or insufficient nolint directives
+    - prealloc      # Finds slice declarations that could potentially be preallocated
+    - rowserrcheck  # Checks whether Err of rows is checked successfully
+    - sqlclosecheck # Checks that sql.Rows and sql.Stmt are closed
+    - errorlint     # Find code that can cause problems with error wrapping
+    - godot         # Check if comments end in a period
+    - gocognit      # Computes and checks the cognitive complexity of functions
+
+  disable:
+    - varnamelen    # Can be too strict for short variable names
+    - exhaustruct   # Can be too strict for struct initialization
+    - tagliatelle   # Can be too opinionated about tag naming
+
+linters-settings:
+  errcheck:
+    # Report about not checking of errors in type assertions: `a := b.(MyStruct)`
+    check-type-assertions: true
+    # Report about assignment of errors to blank identifier: `num, _ := strconv.Atoi(numStr)`
+    check-blank: false
+
+  govet:
+    # Enable all analyzers
+    enable-all: true
+    # Disable shadow checking (can be too strict)
+    disable:
+      - shadow
+
+  gocyclo:
+    # Minimal code complexity to report
+    min-complexity: 15
+
+  dupl:
+    # Tokens count to trigger issue
+    threshold: 100
+
+  goconst:
+    # Minimal length of string constant
+    min-len: 3
+    # Minimum occurrences count to trigger
+    min-occurrences: 3
+
+  misspell:
+    locale: US
+
+  lll:
+    # Max line length, lines longer will be reported
+    line-length: 120
+
+  nakedret:
+    # Make an issue if func has more lines of code than this setting and it has naked returns
+    max-func-lines: 30
+
+  prealloc:
+    # Report preallocation suggestions only on simple loops that have no returns/breaks/continues/gotos in them
+    simple: true
+    range-loops: true
+    for-loops: false
+
+  nolintlint:
+    # Disable to ensure that all nolint directives actually have an effect
+    allow-unused: false
+    # Require an explanation for nolint directives
+    require-explanation: true
+    # Require nolint directives to mention the specific linter being suppressed
+    require-specific: true
+
+  revive:
+    rules:
+      - name: blank-imports
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: dot-imports
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: if-return
+      - name: increment-decrement
+      - name: var-naming
+      - name: var-declaration
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: time-naming
+      - name: unexported-return
+      - name: indent-error-flow
+      - name: errorf
+      - name: empty-block
+      - name: superfluous-else
+      - name: unused-parameter
+      - name: unreachable-code
+      - name: redefines-builtin-id
+
+  gosec:
+    # To specify a set of rules to explicitly exclude
+    excludes:
+      - G104 # Audit errors not checked - covered by errcheck
+
+issues:
+  # List of regexps of issue texts to exclude
+  exclude-rules:
+    # Exclude some linters from running on tests files
+    - path: _test\.go
+      linters:
+        - gocyclo
+        - errcheck
+        - dupl
+        - gosec
+        - goconst
+
+    # Exclude known linters from partially hard-vendored code
+    - path: internal/hmac/
+      text: "weak cryptographic primitive"
+      linters:
+        - gosec
+
+  # Independently from option `exclude` we use default exclude patterns,
+  # it can be disabled by this option. To list all
+  # excluded by default patterns execute `golangci-lint run --help`.
+  exclude-use-default: false
+
+  # Maximum issues count per one linter. Set to 0 to disable
+  max-issues-per-linter: 0
+
+  # Maximum count of issues with the same text. Set to 0 to disable
+  max-same-issues: 0
+
+  # Show only new issues: if there are unstaged changes or untracked files,
+  # only those changes are analyzed
+  new: false

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ test-coverage:
 	go test -coverprofile=coverage.out ./...
 	go tool cover -html=coverage.out
 
-# The lint target runs golint to check for common style issues
+# The lint target runs golangci-lint to check for common style and code quality issues
 lint:
-	golint ./......
+	golangci-lint run ./...
+
+# The lint-install target installs golangci-lint if not already installed
+lint-install:
+	@which golangci-lint > /dev/null || (echo "Installing golangci-lint..." && go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest)


### PR DESCRIPTION
- Update Makefile to use golangci-lint instead of deprecated golint
- Add lint-install target to install golangci-lint if needed
- Create .golangci.yml configuration with comprehensive linter settings
- Enable 27 linters including errcheck, govet, staticcheck, revive, gosec, and more
- Configure linter-specific settings for better code quality checks

This migration modernizes the linting setup to use the current standard
for Go code quality checking.